### PR TITLE
Convert workshop-tonkotsu-nodejs-Pipeline to Github Actions

### DIFF
--- a/.github/workflows/workshop-tonkotsu-nodejs-pipeline.yml
+++ b/.github/workflows/workshop-tonkotsu-nodejs-pipeline.yml
@@ -1,0 +1,17 @@
+name: workshop-tonkotsu-nodejs-Pipeline
+on:
+  workflow_dispatch:
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: sh
+      shell: bash
+      run: npm install
+    - name: sh
+      shell: bash
+      run: npm test


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://13.68.148.199:8080/job/workshop-tonkotsu-nodejs-Pipeline/) :tada: